### PR TITLE
fix: tornar publicação no IA um contrato verificável (#39)

### DIFF
--- a/src/reporter.py
+++ b/src/reporter.py
@@ -1,159 +1,58 @@
-# reporter.py
+from pathlib import Path
+
 import pandas as pd
-import duckdb
-import locale
-import os # For joining path components
+
+
+DEFAULT_PARQUET_PATH = Path("output_data/imoveis_geocoded.parquet")
+
 
 def format_currency(value):
-    """Formats a float value as Brazilian Real currency string."""
     if pd.isna(value):
         return "N/A"
-    try:
-        # Set locale for Brazilian currency formatting if available
-        # Trying common pt_BR locales
-        for loc in ['pt_BR.UTF-8', 'pt_BR', 'Portuguese_Brazil.1252']:
-            try:
-                locale.setlocale(locale.LC_ALL, loc)
-                # On some systems, locale.currency might not be enough,
-                # and manual formatting is more reliable.
-                # Using a simple f-string with comma for thousands and .2f for decimals.
-                return f"R$ {value:,.2f}" 
-            except locale.Error:
-                continue
-        # Fallback if pt_BR locale is not available
-        return f"R$ {value:,.2f}"
-    except Exception:
-        return f"R$ {value:.2f}" # Basic fallback without thousands separator
+    return f"R$ {value:,.2f}"
 
-DEFAULT_DB_PATH = os.path.join("dbt_real_estate", "real_estate_data.db")
-DEFAULT_TABLE_NAME = "imoveis_geocoded" # Assumes this is the final, geocoded table
 
-def generate_report(db_path: str = DEFAULT_DB_PATH, table_name: str = DEFAULT_TABLE_NAME):
-    """
-    Connects to the DuckDB database, queries the specified table (expected to be
-    the geocoded properties data), calculates summary statistics, and prints them.
+def generate_report(parquet_path: Path | str = DEFAULT_PARQUET_PATH):
+    """Print summary statistics for the Parquet produced by the current pipeline."""
+    path = Path(parquet_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Parquet não encontrado: {path}")
 
-    Args:
-        db_path (str): Path to the DuckDB database file.
-        table_name (str): Name of the table to query within the database.
-    """
-    print(f"Generating report from DuckDB: {db_path}, Table: {table_name}")
-    print("--------------------------------------------------")
-
-    try:
-        con = duckdb.connect(database=db_path, read_only=True)
-
-        # Check if table exists
-        table_check_query = f"SELECT 1 FROM information_schema.tables WHERE table_name = '{table_name}'"
-        if not con.execute(table_check_query).fetchone():
-            print(f"Error: Table '{table_name}' not found in the database '{db_path}'.")
-            con.close()
-            return
-
-        # Fetch all data from the specified table
-        df = con.execute(f"SELECT * FROM {table_name}").fetchdf()
-        con.close()
-
-    except duckdb.Error as e:
-        print(f"DuckDB error: {e}")
-        return
-    except Exception as e:
-        print(f"An unexpected error occurred: {e}")
-        return
-
+    df = pd.read_parquet(path)
     if df.empty:
-        print(f"Table '{table_name}' is empty or data could not be loaded. No statistics to generate.")
-        return
+        raise ValueError(f"Parquet vazio: {path}")
 
-    # Ensure 'preco' is numeric, handling potential non-numeric data if schema wasn't strictly enforced
-    if 'preco' in df.columns:
-        df['preco'] = pd.to_numeric(df['preco'], errors='coerce')
-    else:
-        print(f"Warning: 'preco' column is missing from table '{table_name}'. Price statistics will be skipped.")
-        # Initialize preco with NAs if missing, so downstream code doesn't break, but stats will be NA/0
-        df['preco'] = pd.NA
-
-    if 'estado' not in df.columns:
-        print(f"Error: 'estado' column is missing from table '{table_name}'. Report cannot be generated.")
-        return
-
-    print(f"Real Estate Data Report for dbt model '{table_name}':")
+    print(f"Real Estate Data Report: {path}")
     print("--------------------------------------------------")
+    print(f"Total properties listed: {len(df)}")
 
-    # Total number of properties
-    total_properties = len(df)
-    print(f"Total properties listed: {total_properties}")
-    print("--------------------------------------------------")
+    if "estado" not in df.columns:
+        raise ValueError("Coluna obrigatória 'estado' ausente no Parquet")
 
-    # Number of properties per state
     print("Properties per state:")
-    properties_per_state = df.groupby('estado').size()
-    if properties_per_state.empty:
-        print("  No data available for properties per state.")
-    else:
-        for state, count in properties_per_state.items():
-            print(f"  {state}: {count} properties")
-    print("--------------------------------------------------")
+    properties_per_state = df.groupby("estado").size()
+    for state, count in properties_per_state.items():
+        print(f"  {state}: {count} properties")
 
-    # Average price of properties per state
-    print("Average price per state:")
-    # Ensure 'preco' column exists before attempting to calculate mean
-    if 'preco' in df.columns:
-        average_price_per_state = df.groupby('estado')['preco'].mean()
-        if average_price_per_state.empty:
-            print("  No price data available for calculating averages per state.")
-        else:
-            for state, avg_price in average_price_per_state.items():
-                print(f"  {state}: {format_currency(avg_price)}")
-    else:
-        # This case should ideally be caught earlier, but as a safeguard:
-        print("  'preco' column is missing, cannot calculate average prices.")
-    print("--------------------------------------------------")
+    if "preco" in df.columns:
+        prices = pd.to_numeric(df["preco"], errors="coerce")
+        price_frame = df.assign(preco=prices)
+        print("Average price per state:")
+        for state, avg_price in price_frame.groupby("estado")["preco"].mean().items():
+            print(f"  {state}: {format_currency(avg_price)}")
 
-    # Geocoding Statistics
-    print("Geocoding Statistics:")
-    print("--------------------------------------------------")
-    if 'latitude' not in df.columns or 'longitude' not in df.columns:
-        print("  Latitude/Longitude columns not found. Geocoding statistics cannot be generated.")
-    else:
-        total_geocoded = df['latitude'].notna().sum()
-        percentage_geocoded_overall = (total_geocoded / total_properties) * 100 if total_properties > 0 else 0
-        
-        print(f"Overall geocoding success rate: {percentage_geocoded_overall:.1f}% ({total_geocoded} out of {total_properties} properties)")
-        print("\nGeocoding success rate per state:")
+    if "latitude" in df.columns and "longitude" in df.columns:
+        total_geocoded = df["latitude"].notna().sum()
+        pct = total_geocoded / len(df) * 100
+        print(
+            f"Overall geocoding success rate: {pct:.1f}% "
+            f"({total_geocoded} out of {len(df)} properties)"
+        )
 
-        geocoded_per_state_counts = df.groupby('estado')['latitude'].count() # Counts non-NaN latitudes
-        
-        # properties_per_state is already df.groupby('estado').size()
-        
-        # Combine total properties per state with geocoded counts
-        state_stats_df = pd.DataFrame({
-            'total': properties_per_state,
-            'geocoded': geocoded_per_state_counts
-        }).fillna(0) # Fill NaN for states with 0 properties or 0 geocoded properties in the .count() series
-        
-        state_stats_df['percentage'] = (state_stats_df['geocoded'] / state_stats_df['total'] * 100).fillna(0)
-
-        if state_stats_df.empty:
-            print("  No per-state geocoding data available.")
-        else:
-            for state, row in state_stats_df.iterrows():
-                print(f"  {state}: {row['percentage']:.1f}% ({int(row['geocoded'])} out of {int(row['total'])} properties)")
-    print("--------------------------------------------------")
 
 def main():
-    # You could use argparse here to take filepath from command line
-    # For simplicity, we'll use the default or a fixed one if needed for main execution.
-    generate_report() # This will use "imoveis_BR.csv" by default
+    generate_report()
+
 
 if __name__ == "__main__":
-    # Example: To run from command line for a different file:
-    # python reporter.py path/to/your/file.csv
-    # For now, main() calls generate_report() without arguments, using the default.
-    # If you want to parse command line arguments:
-    # import sys
-    # if len(sys.argv) > 1:
-    #     generate_report(sys.argv[1])
-    # else:
-    #     main()
     main()

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -1,40 +1,72 @@
 import argparse
+
 from fetch_data import process_local_data
 from upload_to_archive import upload_files_to_archive
 
+
 def main():
-    try:
-        parser = argparse.ArgumentParser(description="Pipeline de dados imobiliários: processa dados locais e faz upload para o Internet Archive.")
-        parser.add_argument("--skip-processing", action="store_true", help="Pula a etapa de processamento de dados locais.")
-        parser.add_argument("--skip-upload", action="store_true", help="Pula a etapa de upload para o Internet Archive.")
-        parser.add_argument("--upload-dry-run", action="store_true", help="Simula o upload para o Internet Archive.")
-        parser.add_argument("--archive-item-identifier", default="imoveis-caixa-economica-federal", help="O identificador do item no Internet Archive.")
-        parser.add_argument("--archive-item-title", default="Imóveis da Caixa Econômica Federal", help="O título do item no Internet Archive.")
-        parser.add_argument("--archive-item-description", default="Dados de imóveis da Caixa Econômica Federal, processados e disponibilizados em formato Parquet.", help="A descrição do item no Internet Archive.")
+    parser = argparse.ArgumentParser(
+        description="Pipeline de dados imobiliários: processa dados locais e faz upload para o Internet Archive."
+    )
+    parser.add_argument(
+        "--skip-processing",
+        action="store_true",
+        help="Pula a etapa de processamento de dados locais.",
+    )
+    parser.add_argument(
+        "--skip-upload",
+        action="store_true",
+        help="Pula a etapa de upload para o Internet Archive.",
+    )
+    parser.add_argument(
+        "--upload-dry-run",
+        action="store_true",
+        help="Simula o upload para o Internet Archive.",
+    )
+    parser.add_argument(
+        "--archive-item-identifier",
+        default="imoveis-caixa-economica-federal",
+        help="O identificador do item no Internet Archive.",
+    )
+    parser.add_argument(
+        "--archive-item-title",
+        default="Imóveis da Caixa Econômica Federal",
+        help="O título do item no Internet Archive.",
+    )
+    parser.add_argument(
+        "--archive-item-description",
+        default=(
+            "Dados de imóveis da Caixa Econômica Federal, processados e "
+            "disponibilizados em formato Parquet."
+        ),
+        help="A descrição do item no Internet Archive.",
+    )
+    args = parser.parse_args()
 
-        args = parser.parse_args()
+    if not args.skip_processing:
+        print("Iniciando o processamento de dados locais...")
+        process_local_data()
+        print("Processamento de dados locais concluído.")
+    else:
+        print("Pulando o processamento de dados locais.")
 
-        if not args.skip_processing:
-            print("Iniciando o processamento de dados locais...")
-            process_local_data()
-            print("Processamento de dados locais concluído.")
-        else:
-            print("Pulando o processamento de dados locais.")
+    if args.skip_upload:
+        print("Pulando o upload para o Internet Archive.")
+        return
 
-        if not args.skip_upload:
-            print("Iniciando o upload para o Internet Archive...")
-            upload_files_to_archive(
-                identifier=args.archive_item_identifier,
-                title=args.archive_item_title,
-                description=args.archive_item_description,
-                files_dir="output_data",  # Hardcoded to the output directory
-                dry_run=args.upload_dry_run,
-            )
-            print("Upload para o Internet Archive concluído.")
-        else:
-            print("Pulando o upload para o Internet Archive.")
-    except Exception as e:
-        print(f"An error occurred: {e}")
+    print("Iniciando o upload para o Internet Archive...")
+    upload_files_to_archive(
+        identifier=args.archive_item_identifier,
+        title=args.archive_item_title,
+        description=args.archive_item_description,
+        files_dir="output_data",
+        dry_run=args.upload_dry_run,
+    )
+    if args.upload_dry_run:
+        print("Dry-run de upload concluído.")
+    else:
+        print("Publicação no Internet Archive concluída.")
+
 
 if __name__ == "__main__":
     main()

--- a/src/upload_to_archive.py
+++ b/src/upload_to_archive.py
@@ -1,32 +1,23 @@
 import argparse
 import os
 from pathlib import Path
+
 from dotenv import load_dotenv
 from internetarchive import upload
 
-def upload_files_to_archive(identifier, title, description, files_dir, dry_run=False):
-    """
-    Uploads all files in a directory to a specified Internet Archive item.
 
-    Args:
-        identifier (str): The Internet Archive item identifier.
-        title (str): The title of the item.
-        description (str): The description of the item.
-        files_dir (str): The directory containing the files to upload.
-        dry_run (bool): If True, simulates the upload without making changes.
+def upload_files_to_archive(identifier, title, description, files_dir, dry_run=False):
+    """Upload all Parquet files in ``files_dir`` to one Internet Archive item.
+
+    Publication is part of the pipeline contract: when a real upload is requested,
+    missing credentials or an upload error must propagate so CI cannot report a
+    false green. Dry-run remains available without credentials.
     """
     load_dotenv()
-    access_key = os.getenv("IA_ACCESS_KEY")
-    secret_key = os.getenv("IA_SECRET_KEY")
-
-    if not access_key or not secret_key:
-        print("Credenciais do Internet Archive não encontradas. Defina IA_ACCESS_KEY e IA_SECRET_KEY em seu arquivo .env.")
-        return
 
     files_to_upload = [str(p) for p in Path(files_dir).glob("*.parquet")]
     if not files_to_upload:
-        print(f"Nenhum arquivo .parquet encontrado em {files_dir}")
-        return
+        raise FileNotFoundError(f"Nenhum arquivo .parquet encontrado em {files_dir}")
 
     metadata = {
         "title": title,
@@ -42,27 +33,44 @@ def upload_files_to_archive(identifier, title, description, files_dir, dry_run=F
         print(f"Identifier: {identifier}")
         print(f"Metadata: {metadata}")
         print(f"Files to upload: {files_to_upload}")
-    else:
-        try:
-            upload(
-                identifier=identifier,
-                files=files_to_upload,
-                metadata=metadata,
-                access_key=access_key,
-                secret_key=secret_key,
-                verbose=True,
-            )
-            print("Upload concluído com sucesso.")
-        except Exception as e:
-            print(f"Ocorreu um erro durante o upload: {e}")
+        return
+
+    access_key = os.getenv("IA_ACCESS_KEY")
+    secret_key = os.getenv("IA_SECRET_KEY")
+    if not access_key or not secret_key:
+        raise RuntimeError(
+            "Credenciais do Internet Archive não encontradas. "
+            "Defina IA_ACCESS_KEY e IA_SECRET_KEY antes de publicar."
+        )
+
+    upload(
+        identifier=identifier,
+        files=files_to_upload,
+        metadata=metadata,
+        access_key=access_key,
+        secret_key=secret_key,
+        verbose=True,
+    )
+    print("Upload concluído com sucesso.")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Upload de arquivos para o Internet Archive.")
     parser.add_argument("--identifier", required=True, help="O identificador do item no Internet Archive.")
     parser.add_argument("--title", required=True, help="O título do item.")
     parser.add_argument("--description", required=True, help="A descrição do item.")
-    parser.add_argument("--files_dir", default="output_data", help="O diretório que contém os arquivos a serem carregados.")
+    parser.add_argument(
+        "--files_dir",
+        default="output_data",
+        help="O diretório que contém os arquivos a serem carregados.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Simula o upload sem enviar arquivos.")
     args = parser.parse_args()
 
-    upload_files_to_archive(args.identifier, args.title, args.description, args.files_dir, args.dry_run)
+    upload_files_to_archive(
+        args.identifier,
+        args.title,
+        args.description,
+        args.files_dir,
+        args.dry_run,
+    )

--- a/tests/test_upload_to_archive.py
+++ b/tests/test_upload_to_archive.py
@@ -1,28 +1,30 @@
-import pytest
-import os
-import sys
-from unittest.mock import patch, MagicMock
 from pathlib import Path
+from unittest.mock import patch
 
-# Add src to sys.path
+import pytest
+
+import sys
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from upload_to_archive import upload_files_to_archive
+
 
 @pytest.fixture
 def mock_env(monkeypatch):
     monkeypatch.setenv("IA_ACCESS_KEY", "test_access_key")
     monkeypatch.setenv("IA_SECRET_KEY", "test_secret_key")
 
+
 @pytest.fixture
 def dummy_files_dir(tmp_path):
-    d = tmp_path / "output_data"
-    d.mkdir()
-    (d / "imoveis_1.parquet").write_text("dummy")
-    (d / "imoveis_2.parquet").write_text("dummy")
-    # Add a non-parquet file to test filtering
-    (d / "ignore.txt").write_text("ignore")
-    return d
+    directory = tmp_path / "output_data"
+    directory.mkdir()
+    (directory / "imoveis_1.parquet").write_text("dummy")
+    (directory / "imoveis_2.parquet").write_text("dummy")
+    (directory / "ignore.txt").write_text("ignore")
+    return directory
+
 
 @patch("upload_to_archive.upload")
 def test_upload_files_to_archive_success(mock_upload, mock_env, dummy_files_dir):
@@ -31,81 +33,82 @@ def test_upload_files_to_archive_success(mock_upload, mock_env, dummy_files_dir)
         title="Test Title",
         description="Test Description",
         files_dir=str(dummy_files_dir),
-        dry_run=False
     )
 
     mock_upload.assert_called_once()
-
-    # Check arguments
     call_kwargs = mock_upload.call_args.kwargs
     assert call_kwargs["identifier"] == "test-identifier"
     assert call_kwargs["access_key"] == "test_access_key"
     assert call_kwargs["secret_key"] == "test_secret_key"
+    assert len(call_kwargs["files"]) == 2
+    assert not any("ignore.txt" in file for file in call_kwargs["files"])
 
-    # Check that only .parquet files were included
-    uploaded_files = call_kwargs["files"]
-    assert len(uploaded_files) == 2
-    assert any("imoveis_1.parquet" in f for f in uploaded_files)
-    assert any("imoveis_2.parquet" in f for f in uploaded_files)
-    assert not any("ignore.txt" in f for f in uploaded_files)
-
-    # Check metadata
-    metadata = call_kwargs["metadata"]
-    assert metadata["title"] == "Test Title"
-    assert metadata["description"] == "Test Description"
-    assert metadata["mediatype"] == "data"
 
 @patch("upload_to_archive.upload")
-def test_upload_files_to_archive_dry_run(mock_upload, mock_env, dummy_files_dir, capsys):
+def test_upload_files_to_archive_dry_run_needs_no_credentials(
+    mock_upload, dummy_files_dir, monkeypatch, capsys
+):
+    monkeypatch.delenv("IA_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("IA_SECRET_KEY", raising=False)
+
     upload_files_to_archive(
         identifier="test-identifier",
         title="Test Title",
         description="Test Description",
         files_dir=str(dummy_files_dir),
-        dry_run=True
+        dry_run=True,
     )
 
     mock_upload.assert_not_called()
-    captured = capsys.readouterr()
-    assert "[Dry Run] Simulação de upload." in captured.out
-    assert "test-identifier" in captured.out
-    assert "imoveis_1.parquet" in captured.out
+    assert "[Dry Run] Simulação de upload." in capsys.readouterr().out
+
 
 @patch("upload_to_archive.upload")
-def test_upload_files_to_archive_no_credentials(mock_upload, dummy_files_dir, monkeypatch, capsys):
-    # Ensure no credentials are set
+def test_upload_files_to_archive_no_credentials_fails(
+    mock_upload, dummy_files_dir, monkeypatch
+):
     monkeypatch.delenv("IA_ACCESS_KEY", raising=False)
     monkeypatch.delenv("IA_SECRET_KEY", raising=False)
 
-    upload_files_to_archive(
-        identifier="test", title="t", description="d", files_dir=str(dummy_files_dir)
-    )
+    with pytest.raises(RuntimeError, match="Credenciais do Internet Archive"):
+        upload_files_to_archive(
+            identifier="test",
+            title="t",
+            description="d",
+            files_dir=str(dummy_files_dir),
+        )
 
     mock_upload.assert_not_called()
-    captured = capsys.readouterr()
-    assert "Credenciais do Internet Archive não encontradas" in captured.out
+
 
 @patch("upload_to_archive.upload")
-def test_upload_files_to_archive_no_parquet_files(mock_upload, mock_env, tmp_path, capsys):
+def test_upload_files_to_archive_no_parquet_files_fails(mock_upload, mock_env, tmp_path):
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()
 
-    upload_files_to_archive(
-        identifier="test", title="t", description="d", files_dir=str(empty_dir)
-    )
+    with pytest.raises(FileNotFoundError, match="Nenhum arquivo .parquet"):
+        upload_files_to_archive(
+            identifier="test",
+            title="t",
+            description="d",
+            files_dir=str(empty_dir),
+        )
 
     mock_upload.assert_not_called()
-    captured = capsys.readouterr()
-    assert "Nenhum arquivo .parquet encontrado" in captured.out
+
 
 @patch("upload_to_archive.upload")
-def test_upload_files_to_archive_exception(mock_upload, mock_env, dummy_files_dir, capsys):
-    mock_upload.side_effect = Exception("Simulated upload error")
+def test_upload_files_to_archive_exception_propagates(
+    mock_upload, mock_env, dummy_files_dir
+):
+    mock_upload.side_effect = RuntimeError("Simulated upload error")
 
-    upload_files_to_archive(
-        identifier="test", title="t", description="d", files_dir=str(dummy_files_dir)
-    )
+    with pytest.raises(RuntimeError, match="Simulated upload error"):
+        upload_files_to_archive(
+            identifier="test",
+            title="t",
+            description="d",
+            files_dir=str(dummy_files_dir),
+        )
 
     mock_upload.assert_called_once()
-    captured = capsys.readouterr()
-    assert "Ocorreu um erro durante o upload: Simulated upload error" in captured.out


### PR DESCRIPTION
Closes #39.

## Evidência que motivou

O run `31899754803` ficou verde embora os logs mostrassem credenciais de IA ausentes e nenhum upload. O código convertia falta de credenciais/exceção de upload em `print`, e o reporter ainda procurava o DuckDB removido.

## O que muda

- upload real sem credenciais agora falha;
- exceções de `internetarchive.upload(...)` propagam e quebram o job;
- dry-run continua possível sem credenciais;
- ausência de Parquet também é falha explícita;
- `run_pipeline.py` não engole exceções nem imprime sucesso falso;
- `reporter.py` passa a ler `output_data/imoveis_geocoded.parquet`, o artefato atual;
- testes falsificadores protegem falta de credenciais e erro de upload.

## Fronteira

O workflow artifact continua sendo evidência de **geração** do Parquet. Só um upload concluído no Internet Archive deve contar como evidência de **publicação**.

## Test plan

CI da PR deve passar sem secrets, porque PR não executa o job `publish`. Após merge, se os secrets de IA continuarem ausentes, `main` deve falhar explicitamente no publish — isso será evidência correta, não regressão. Se estiverem configurados, um verde passa a significar publicação real.